### PR TITLE
Modification to handle MySQL tables

### DIFF
--- a/main/plugin/datasource_MySQL.py
+++ b/main/plugin/datasource_MySQL.py
@@ -20,7 +20,7 @@ class DataSource_MySQL(DataSource_SQL):
                 self.url = 'mysql://' + self.url
 
             # TODO: the port number should be omittable
-            pattern = r"mysql://(\w+):(\w+)@(\w+):(\d+)/(\w+)"
+            pattern = r"mysql://([\w.-]+):(.+?)@([\w.-]+):(\d+)/([\w.-]+)"
             match = re.match(pattern, self.url)
             if match:
                 self.user     = match.group(1)

--- a/main/plugin/datasource_MySQL.py
+++ b/main/plugin/datasource_MySQL.py
@@ -50,6 +50,9 @@ class DataSource_MySQL(DataSource_SQL):
         return SQLServer(conn)
 
     # Override
-    def _get_timestamp_in_query(self, var_name):
-        # Should we care the case the variable is not a epoch (integer) value, e.g. TIMESTAMP?
-        return var_name
+    def _get_timediffsec_query(self, time_col, time_type, stop_sec, stop_tstamp):
+        if time_type == 'unix':
+            return f"{stop_sec} - {time_col}"
+        else:
+            return f"TIME_TO_SEC( TIMEDIFF({stop_tstamp}, {time_col}) )"
+        

--- a/main/plugin/datasource_MySQL.py
+++ b/main/plugin/datasource_MySQL.py
@@ -1,35 +1,55 @@
 # Created by Sanshiro Enomoto on 10 April 2023 #
-
+# Edited by Kou Oishi and Yuto Kageyama on 22 October 2024 #
 
 import sys, os, logging
 from datasource_SQL import SQLServer, DataSource_SQL
 
-import MyDQLdb as db
+import MySQLdb as db
+import re
 
-
-class DataSource_PostgreSQL(DataSource_SQL):
+class DataSource_MySQL(DataSource_SQL):
     def __init__(self, project_config, config):
         super().__init__(project_config, config)
         
         self.db_has_floor = True
-        
-        self.url = config.get('url', None)
-        if self.url is not None and self.url[0:8] != 'mysql://':
-            self.url = 'mysql://' + self.url
 
+        # Parse the PostgreSQL-style URL into each parameter
+        self.url = config.get('url', None)
+        if self.url is not None:
+            if self.url[0:8] != 'mysql://':
+                self.url = 'mysql://' + self.url
+
+            # TODO: the port number should be omittable
+            pattern = r"mysql://(\w+):(\w+)@(\w+):(\d+)/(\w+)"
+            match = re.match(pattern, self.url)
+            if match:
+                self.user     = match.group(1)
+                self.password = match.group(2)
+                self.host     = match.group(3)
+                self.port     = int(match.group(4))
+                self.database = match.group(5)
+            else:
+                logging.error("Syntax error in the URL: %s" % (self.url))
             
     def connect(self):
         if self.url is None:
             return super().connect()
         
         try:
-            conn = db.connect(self.url)
+            conn = db.connect(host=self.host, port=self.port, user=self.user,
+                              password=self.password, database=self.database,
+                              autocommit=True)
         except Exception as e:
             logging.error("MySQL: %s: %s" % (self.url, str(e)))
             return super().connect()
         if conn is None:
             return super().connect()
-
+        
         logging.info('MySQL: DB connected: "%s"' % self.url)
         
         return SQLServer(conn)
+
+    # Override
+    def _get_timestamp_in_query(self, var_name):
+        # Should we care the case the variable is not a epoch (integer) value, e.g. TIMESTAMP?
+        return var_name

--- a/main/server/datasource.py
+++ b/main/server/datasource.py
@@ -32,13 +32,14 @@ class Schema:
         self.parse(self.init_description)
 
             
-    def add_channel(self, channel_name, field_type=None):
-        if channel_name not in self.channel_table:
-            self.channel_table[channel_name] = { 'name': channel_name }
+    def add_channel(self, channel_name : str, field_type=None):
+        channel_name_str = str(channel_name)
+        if channel_name_str not in self.channel_table:
+            self.channel_table[channel_name_str] = { 'name': channel_name_str }
         else:
-            self.channel_table[channel_name]['name'] = channel_name
+            self.channel_table[channel_name_str]['name'] = channel_name_str
         if field_type is not None:
-            self.channel_table[channel_name]['type'] = field_type
+            self.channel_table[channel_name_str]['type'] = field_type
 
                     
     def parse(self, schema):

--- a/main/server/datasource_SQL.py
+++ b/main/server/datasource_SQL.py
@@ -281,7 +281,7 @@ class DataSource_SQL(DataSource_TableStore):
         elif resampling is None or resampling <= 0:
             pass
         else:
-            convtime = _get_timestamp_in_query(time_col)
+            convtime = self._get_timestamp_in_query(time_col)
             
             if reducer in ['first', 'last'] and self.db_has_floor:
                 sql_cte_bucket = ' '.join([

--- a/main/server/datasource_TableStore.py
+++ b/main/server/datasource_TableStore.py
@@ -42,10 +42,11 @@ class DataSource_TableStore(DataSource):
         channels = []
         for schema in self.ts_schemata + self.obj_schemata + self.objts_schemata:
             for ch in schema.channel_table.values():
+                ch_str = str(ch['name'])
                 if 'type' in ch:
-                    channels.append({ 'name': ch['name'] + schema.suffix, 'type': ch['type'] })
+                    channels.append({ 'name': ch_str + schema.suffix, 'type': ch['type'] })
                 else:
-                    channels.append({ 'name': ch['name'] + schema.suffix })
+                    channels.append({ 'name': ch_str + schema.suffix })
                 
         return channels
         
@@ -192,12 +193,13 @@ class DataSource_TableStore(DataSource):
                             channel_name = tag_value
                         else:
                             channel_name = '%s%s%s' % (tag_value, Schema.tag_field_separator, field)
-                        schema.add_channel(channel_name)
-                        field_type = schema.channel_table[channel_name].get('type', None)
+                        channel_name_str = str(channel_name)
+                        schema.add_channel(channel_name_str)
+                        field_type = schema.channel_table[channel_name_str].get('type', None)
                         if (not schema.is_for_ts) and (field_type is None):
                             value = self._get_first_data_value(schema.table, schema.tag, tag_value, field)
                             if value is not None:
-                                schema.add_channel(channel_name, Schema.identify_datatype(value))
+                                schema.add_channel(channel_name_str, Schema.identify_datatype(value))
 
 
     def _get_query_result(self, schema, channels, length, to, resampling=None, reducer=None, lastonly=False):
@@ -213,7 +215,7 @@ class DataSource_TableStore(DataSource):
             if not name.replace('.', '').replace('_', '').replace('-', '').replace(':', '').isalnum():
                 logging.error('bad channel name: %s' % name)
             else:
-                key = name[0:len(name)-len(schema.suffix)]
+                key = str(name[0:len(name)-len(schema.suffix)])
                 if key in schema.channel_table:
                     target_channels.append(key)
         if len(target_channels) == 0:

--- a/main/server/datasource_TableStore.py
+++ b/main/server/datasource_TableStore.py
@@ -31,7 +31,7 @@ class DataSource_TableStore(DataSource):
 
         
     # override this
-    def _execute_query(self, table_name, time_col, time_from, time_to, tag, tag_values, fields, resampling=None, reducer=None, stop=None, lastonly=False):
+    def _execute_query(self, table_name, time_col, time_type, time_from, time_to, tag, tag_values, fields, resampling=None, reducer=None, stop=None, lastonly=False):
         columns, table = [], []
         return columns, table
 
@@ -231,7 +231,7 @@ class DataSource_TableStore(DataSource):
 
         query_result_columns, query_result_table = self._execute_query(
             schema.table, 
-            time_col, time_from, time_to, 
+            time_col, schema.time_type, time_from, time_to, 
             schema.tag, tag_values, fields,
             resampling=resampling, reducer=reducer, stop=stop,
             lastonly=lastonly

--- a/main/server/slowdash.py
+++ b/main/server/slowdash.py
@@ -5,7 +5,7 @@
 import sys, os, stat, pathlib, pwd, grp, io, time, glob, json, yaml, logging
 import datasource, usermodule, taskmodule
 from slowdash_config import Config
-
+from decimal import Decimal
 
 class App:
     def __init__(self, project_dir=None, project_file=None, is_cgi=False, is_command=False):
@@ -266,7 +266,11 @@ class App:
             if type(result) is str:
                 output.write(result.encode())
             else:
-                output.write(json.dumps(result).encode())
+                # To convert decimal values into numbers that can be handled by JSON
+                def decimal_to_num(obj):
+                    if isinstance(obj, Decimal):
+                        return int(obj) if float(obj).is_integer() else float(obj)
+                output.write(json.dumps(result, default=decimal_to_num).encode())
             
         return content_type
 


### PR DESCRIPTION
The current implementation seems not to handle MySQL tables properly, unfortunately.
This request modifies that by making `datasource_SQL.py` a bit more generic, also including fixing a few minor mistakes.

The part getting the time difference in seconds in `DataSourceSQL::_execute_query` contains a syntax available (only?) in PostgreSQL. 
For example, `extract(epoch from {time_col})` does not work in MySQL.
Newly `_get_timediffsec_query()` is defined to give a proper query expression depending on the SQL type. 
It should be orverrided by each `datasource_*` plugin.

In addition, I modified the core part handling the channel column so that those make sure the channel column is converted into string even if it is a pure integer.
