### PR TITLE
Fixed accidentally commented out .sd-header subsequent issues

### DIFF
--- a/app/server/sd_version.py
+++ b/app/server/sd_version.py
@@ -1,1 +1,1 @@
-slowdash_version = '260411 "Nooksack"'
+slowdash_version = '260413 "Nooksack"'

--- a/app/site/slowjs/slowdash.css
+++ b/app/site/slowjs/slowdash.css
@@ -127,6 +127,7 @@ summary {
    ≤ 640 px  Each column takes a full row; the clock is hidden to
              save space; the right column switches from column to
              row layout so buttons stay on one accessible row.
+*/
 
 .sd-header {
     display: flex;


### PR DESCRIPTION
  1. Fixed 4-row header: .sd-header { display: flex; } is no longer commented out, so
  the left and right columns sit side by side as intended
  2. Fixed light mode colors not working  background: var(--sd-header-bg) and color:
  var(--sd-header-color) now apply, so the UW purple (#460084) and white text from
  slowdash-light.css take effect
  3. Fixed default to white background - default theme is 'light',
  slowdash-light.css is always loaded and sets --sd-header-bg: #460084.
  .sd-header rule now active, that purple background is applied even when no style is
  specified in SlowdashProject.yaml