### PR TITLE
Modify MySQL_NoAsync.py: this was missing in the last PR for MySQL.py

### DIFF
--- a/app/plugin/datasource_MySQL.py
+++ b/app/plugin/datasource_MySQL.py
@@ -58,7 +58,6 @@ class AsyncMySQLServer(SQLBaseServer):
             async with self.pool.acquire() as conn:
                 async with conn.cursor() as cursor:
                     await cursor.execute(sql, params)
-                    await conn.commit()
         except Exception as e:
             if not self.connection_error_reported:
                 logging.error(f'MySQL Async Execute Error: {e}')
@@ -81,7 +80,6 @@ class AsyncMySQLServer(SQLBaseServer):
             async with self.pool.acquire() as conn:
                 async with conn.cursor(aiomysql.DictCursor) as cursor:
                     await cursor.execute(sql, params)
-                    await conn.commit()
                     rows = await cursor.fetchall()
         except Exception as e:
             if not self.connection_error_reported:
@@ -124,7 +122,8 @@ class DataSource_MySQL(DataSource_SQL):
 
         try:
             pool = await aiomysql.create_pool(
-                host=self.host, port=self.port, user=self.user, password=self.password, db=self.database
+                host=self.host, port=self.port, user=self.user, password=self.password, db=self.database,
+                autocommit=True
             )
         except Exception as e:
             logging.error(f'AsyncMySQL: {self.url}: {e}')

--- a/app/plugin/datasource_MySQL_NoAsync.py
+++ b/app/plugin/datasource_MySQL_NoAsync.py
@@ -39,7 +39,8 @@ class DataSource_MySQL_NoAsync(DataSource_SQL):
         try:
             conn = mysql.connect(
                 host=self.host, port=self.port, user=self.user,
-                password=self.password, database=self.database
+                password=self.password, database=self.database,
+                autocommit=True
             )
         except Exception as e:
             logging.error("MySQL: %s: %s" % (self.url, str(e)))

--- a/app/server/sd_version.py
+++ b/app/server/sd_version.py
@@ -1,1 +1,1 @@
-slowdash_version = '260602 "Stawamus"'
+slowdash_version = '260623 "Stawamus"'


### PR DESCRIPTION
This PR modifies MySQL_NoAsync plugin for the same reason as in https://github.com/slowproj/slowdash/pull/5 
This patch was missing in that PR.